### PR TITLE
Attribute modifiers on the armor incorrect value

### DIFF
--- a/src/main/java/ichttt/mods/firstaid/common/util/ArmorUtils.java
+++ b/src/main/java/ichttt/mods/firstaid/common/util/ArmorUtils.java
@@ -132,7 +132,7 @@ public class ArmorUtils {
     }
 
     private static double getValueFromAttributes(Attribute attribute, EquipmentSlotType slot, ItemStack stack) {
-        return stack.getItem().getAttributeModifiers(slot, stack).get(attribute).stream().mapToDouble(AttributeModifier::getAmount).sum();
+        return stack.getAttributeModifiers(slot).get(attribute).stream().mapToDouble(AttributeModifier::getAmount).sum();
     }
 
     private static double getGlobalRestAttribute(PlayerEntity player, Attribute attribute) {
@@ -162,9 +162,8 @@ public class ArmorUtils {
         float totalArmor = 0F;
         float totalToughness = 0F;
         if (item instanceof ArmorItem) {
-            ArmorItem armor = (ArmorItem) item;
-            totalArmor = armor.getDefense();
-            totalToughness = armor.getToughness(); //getToughness
+            totalArmor = (float) getValueFromAttributes(Attributes.ARMOR, slot, itemStack);
+            totalToughness = (float) getValueFromAttributes(Attributes.ARMOR_TOUGHNESS, slot, itemStack); //getToughness
             totalArmor = (float) applyArmorModifier(slot, totalArmor);
             totalToughness = (float) applyToughnessModifier(slot, totalToughness);
         }


### PR DESCRIPTION
- Fixes the attribute modifiers on armor don't add into the calculation of damage reduction.
Tested with CraftTweaker, IItemStack.addGlobalAttributeModifier.
E.G
<item:minecraft:leather_chestplate>.addGlobalAttributeModifier(<attribute:minecraft:generic.armor>, "Extra Armor", 10, AttributeOperation.ADDITION, [<equipmentslottype:chest>]);
but still shows up as leather chestplate's default armor value instead of (default_leather_armor_value + 10).