### PR TITLE
Add handling for NaN/Positive Infinity damage

### DIFF
--- a/src/main/java/ichttt/mods/firstaid/common/EventHandler.java
+++ b/src/main/java/ichttt/mods/firstaid/common/EventHandler.java
@@ -110,7 +110,7 @@ public class EventHandler {
         AbstractPlayerDamageModel damageModel = Objects.requireNonNull(player.getCapability(CapabilityExtendedHealthSystem.INSTANCE, null));
         DamageSource source = event.getSource();
 
-        if (amountToDamage == Float.MAX_VALUE) {
+        if (amountToDamage == Float.MAX_VALUE || Float.isNaN(amountToDamage) || amountToDamage == Float.POSITIVE_INFINITY) {
             damageModel.forEach(damageablePart -> damageablePart.currentHealth = 0F);
             if (player instanceof EntityPlayerMP)
                 FirstAid.NETWORKING.sendTo(new MessageSyncDamageModel(damageModel, false), (EntityPlayerMP) player);


### PR DESCRIPTION
Fixes death desyncs that can be caused by various sources, such as multiplying the damage by itself while a /kill command is being run, resulting in NaN instead of Float.MAX_VALUE.