### PR TITLE
Fix for Epic Fight incompatibility (stamina not loading)

### DIFF
--- a/src/main/java/ichttt/mods/firstaid/common/SynchedEntityDataWrapper.java
+++ b/src/main/java/ichttt/mods/firstaid/common/SynchedEntityDataWrapper.java
@@ -185,4 +185,7 @@ public class SynchedEntityDataWrapper extends SynchedEntityData {
     public boolean isEmpty() {
         return parent.isEmpty();
     }
+    public <T> boolean hasItem(EntityDataAccessor<T> pKey) {
+        return parent.hasItem(pKey);
+    }
 }


### PR DESCRIPTION
First Aid creates the SynchedEntityDataWrapper that replaces the SynchedEntityData. When Epic Fight searches for stamina, it doesn't find it, because it searches in the SynchedEntityDataWrapper. If you try to set it, it will give an error, because the SynchedEntityDataWrapper redirects to the SynchedEntityData, where STAMINA exists. I'm just redirecting the hasItem, to the parent.